### PR TITLE
VST2 Support on Linux available

### DIFF
--- a/Dexed.jucer
+++ b/Dexed.jucer
@@ -118,8 +118,8 @@
     </GROUP>
   </MAINGROUP>
   <EXPORTFORMATS>
-    <LINUX_MAKE targetFolder="Builds/Linux" vstFolder="~/src/vstsdk2.4" smallIcon="SpSpb4"
-                bigIcon="SpSpb4">
+    <LINUX_MAKE targetFolder="Builds/Linux" vstLegacyFolder="VST2SDK_DIR" smallIcon="SpSpb4"
+                bigIcon="SpSpb4" extraLinkerFlags="-fPIC">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="Dexed"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="2" targetName="Dexed"/>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The surge synth team has a branch of dexed to do a few things
 
 At this time this is a work in progress. Probably best to not pay too much attention...
 
-
+If you want to build this, you may notice the JUCER files are gone. THat's OK! We build them as needed now using a set of
+scripts. Your easiest path is to run 'scripts/build.sh' but this documentation will improve shortly.
 
 
 Dexed - FM Plugin Synth

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ At this time this is a work in progress. Probably best to not pay too much atten
 If you want to build this, you may notice the JUCER files are gone. THat's OK! We build them as needed now using a set of
 scripts. Your easiest path is to run 'scripts/build.sh' but this documentation will improve shortly.
 
+Since Steinberg has discontinued the VST2 API we no longer distribute it. On Mac and Windows we strongly recommend you
+use the provided VST3. On Linux, the situation is a little trickier, with VST3 support in hosts being uneven. If you
+are a licensee to the VST2SDK, though, you can build a VST2 version of DEXED yourself with these commands
+
+```
+./scripts/get-juce.sh
+export VST2SDK_DIR=~/path/to/vst2/sdk/dir
+./scripts/projuce-lin-vst2.sh
+./scripts/build-lin.sh
+```
+
+and you will get a VST2 and Standalone as opposed to just a Standalone.
+
 
 Dexed - FM Plugin Synth
 =======================

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,8 @@ jobs:
       
       git submodule update --init --recursive
 
+      ./scripts/set-version.sh
+
     displayName: Setup for Building
 
   - bash: |
@@ -167,14 +169,23 @@ jobs:
     displayName: Fake up release notes
 
   - task: GitHubRelease@0
-    displayName: "Update Github Release"
+    displayName: "Delete Prior Github Release"
     inputs:
       gitHubConnection: surge-rackupdater
       repositoryName: surge-synthesizer/dexed
-      action: edit
+      action: 'delete'
+      tag: Nightly
+
+  - task: GitHubRelease@0
+    displayName: "Create New Github Release"
+    inputs:
+      gitHubConnection: surge-rackupdater
+      repositoryName: surge-synthesizer/dexed
+      action: 'create'
       tag: Nightly
       target: '$(Build.SourceVersion)'
       addChangeLog: false
+      assetUploadMode: 'delete'
       releaseNotesFile: $(Build.ArtifactStagingDirectory)/ReleaseNotes.md
       assets: $(Build.ArtifactStagingDirectory)/*.*
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This shell script does, more or less, waht the azure pipelines do for you if you
+# just want a clean build
+
+OS=`uname -s`
+JOS=win
+
+if [[ $OS == "Darwin" ]]; then
+  JOS=mac
+fi
+
+if [[ $OS == "Linux" ]]; then
+  JOS=lin
+fi
+
+
+if [ ! -f "assets/JUCE/LICENSE.md" ]; then
+    ./scripts/get-juce.sh
+fi
+
+./scripts/projuce-${JOS}.sh
+./scripts/build-${JOS}.sh
+./scripts/package-${JOS}.sh
+

--- a/scripts/package-lin.sh
+++ b/scripts/package-lin.sh
@@ -2,7 +2,7 @@
 
 GIT_TAG=`git rev-parse --short HEAD`
 BUILDDATE=`date +%Y%m%d`
-VERSION="bp-${GIT_TAG}-${BUILDDATE}"
+VERSION="${GIT_TAG}-${BUILDDATE}"
 
 rm -rf Builds/Linux/Dexed-Nightly
 mkdir -p Builds/Linux/Dexed-Nightly

--- a/scripts/package-mac.sh
+++ b/scripts/package-mac.sh
@@ -2,7 +2,7 @@
 
 GIT_TAG=`git rev-parse --short HEAD`
 BUILDDATE=`date +%Y%m%d`
-VERSION="bp-${GIT_TAG}-${BUILDDATE}"
+VERSION="${GIT_TAG}-${BUILDDATE}"
 
 rm -rf Builds/MacOSX/Dexed-Nightly
 rm -rf *dmg

--- a/scripts/projuce-lin-vst2.sh
+++ b/scripts/projuce-lin-vst2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z $VST2SDK_DIR ]; then
+    echo "VST2SDK_DIR is not set. Please point it to a directory containing the VST2 SDK"
+    exit 1
+else
+   sed -e 's/,buildVST3/,buildVST,buildVST3/' Dexed.jucer | \
+	sed -e "s@VST2SDK_DIR@${VST2SDK_DIR}@" | \
+	sed -e 's/PLUGINHOST_VST="0"/PLUGINHOST_VST="1"/' | \
+	sed -e 's/buildVST="0"/buildVST="1"/' > Dexed-vst2.jucer
+   mv Dexed.jucer Dexed-orig.jucer
+   mv Dexed-vst2.jucer Dexed.jucer
+   assets/JUCE/Projucer --resave Dexed.jucer
+   mv Dexed-orig.jucer Dexed.jucer
+fi
+


### PR DESCRIPTION
VST2 Support is now available, but for clarity, it will not
work unless you provide your own licensed copy of the VST2SDK.
We do not distribute the VST2SDK