### PR TITLE
Initial MPE Support

### DIFF
--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -255,6 +255,22 @@ ParamDialog::ParamDialog ()
 
     transposeScale->setBounds (576, 240, 56, 24);
 
+    mpePBRange.reset (new Slider ("mpePBRange"));
+    addAndMakeVisible (mpePBRange.get());
+    mpePBRange->setRange (0, 99, 1);
+    mpePBRange->setSliderStyle (Slider::RotaryVerticalDrag);
+    mpePBRange->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    mpePBRange->addListener (this);
+
+    mpePBRange->setBounds (616, 288, 72, 24);
+
+    mpeEnabled.reset (new LightedToggleButton ("mpeEnabled"));
+    addAndMakeVisible (mpeEnabled.get());
+    mpeEnabled->setButtonText (String());
+    mpeEnabled->addListener (this);
+
+    mpeEnabled->setBounds (448, 288, 56, 24);
+
 
     //[UserPreSize]
     //[/UserPreSize]
@@ -314,6 +330,8 @@ ParamDialog::~ParamDialog()
     showTunButton = nullptr;
     resetTuningButton = nullptr;
     transposeScale = nullptr;
+    mpePBRange = nullptr;
+    mpeEnabled = nullptr;
 
 
     //[Destructor]. You can add your own custom destruction code here..
@@ -544,6 +562,39 @@ void ParamDialog::paint (Graphics& g)
                     Justification::centredLeft, true);
     }
 
+    {
+        int x = 368, y = 280, width = 328, height = 1;
+        Colour fillColour = Colours::black;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.fillRect (x, y, width, height);
+    }
+
+    {
+        int x = 371, y = 288, width = 276, height = 27;
+        String text (TRANS("MPE"));
+        Colour fillColour = Colours::white;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.setFont (Font (15.00f, Font::plain).withTypefaceStyle ("Regular"));
+        g.drawText (text, x, y, width, height,
+                    Justification::centredLeft, true);
+    }
+
+    {
+        int x = 528, y = 288, width = 119, height = 27;
+        String text (TRANS("Bend Range"));
+        Colour fillColour = Colours::white;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.setFont (Font (15.00f, Font::plain).withTypefaceStyle ("Regular"));
+        g.drawText (text, x, y, width, height,
+                    Justification::centredLeft, true);
+    }
+
     //[UserPaint] Add your own custom painting code here..
     if ( ! JUCEApplication::isStandaloneApp() ) {
         g.setColour (Colours::white);
@@ -611,6 +662,11 @@ void ParamDialog::sliderValueChanged (Slider* sliderThatWasMoved)
     {
         //[UserSliderCode_atRange] -- add your slider handling code here..
         //[/UserSliderCode_atRange]
+    }
+    else if (sliderThatWasMoved == mpePBRange.get())
+    {
+        //[UserSliderCode_mpePBRange] -- add your slider handling code here..
+        //[/UserSliderCode_mpePBRange]
     }
 
     //[UsersliderValueChanged_Post]
@@ -751,6 +807,11 @@ void ParamDialog::buttonClicked (Button* buttonThatWasClicked)
         //[UserButtonCode_transposeScale] -- add your button handler code here..
         //[/UserButtonCode_transposeScale]
     }
+    else if (buttonThatWasClicked == mpeEnabled.get())
+    {
+        //[UserButtonCode_mpeEnabled] -- add your button handler code here..
+        //[/UserButtonCode_mpeEnabled]
+    }
 
     //[UserbuttonClicked_Post]
     if( ! handled )
@@ -792,6 +853,9 @@ void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool
 
     transposeScale->setToggleState(c.transpose12AsScale ? 0 : 1, dontSendNotification );
 
+    mpeEnabled->setToggleState(c.mpeEnabled, dontSendNotification);
+    mpePBRange->setValue(c.mpePitchBendRange, dontSendNotification);
+    
     StringArray inputs = MidiInput::getDevices();
     int idx = inputs.indexOf(mgr.getInput());
     idx = idx == -1 ? 0 : idx + 1;
@@ -834,6 +898,9 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
 
     c.transpose12AsScale = ! transposeScale->getToggleState();
 
+    c.mpeEnabled = mpeEnabled->getToggleState();
+    c.mpePitchBendRange = mpePBRange->getValue();
+    
     c.refresh();
 
     if ( ! JUCEApplication::isStandaloneApp() ) {
@@ -920,6 +987,13 @@ BEGIN_JUCER_METADATA
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
     <TEXT pos="643 242 45 25" fill="solid: ffffffff" hasStroke="0" text="Value"
+          fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
+          italic="0" justification="33"/>
+    <RECT pos="368 280 328 1" fill="solid: ff000000" hasStroke="0"/>
+    <TEXT pos="371 288 276 27" fill="solid: ffffffff" hasStroke="0" text="MPE"
+          fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
+          italic="0" justification="33"/>
+    <TEXT pos="528 288 119 27" fill="solid: ffffffff" hasStroke="0" text="Bend Range"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
   </BACKGROUND>
@@ -1022,6 +1096,15 @@ BEGIN_JUCER_METADATA
               connectedEdges="0" needsCallback="1" radioGroupId="0"/>
   <TOGGLEBUTTON name="transposeScale" id="9d4dd65775ed9e38" memberName="transposeScale"
                 virtualName="LightedToggleButton" explicitFocusOrder="0" pos="576 240 56 24"
+                buttonText="" connectedEdges="0" needsCallback="1" radioGroupId="0"
+                state="0"/>
+  <SLIDER name="mpePBRange" id="a13948d1cc74a51a" memberName="mpePBRange"
+          virtualName="" explicitFocusOrder="0" pos="616 288 72 24" min="0.0"
+          max="96.0" int="1.0" style="RotaryVerticalDrag" textBoxPos="TextBoxLeft"
+          textBoxEditable="1" textBoxWidth="80" textBoxHeight="20" skewFactor="1.0"
+          needsCallback="1"/>
+  <TOGGLEBUTTON name="mpeEnabled" id="e1a11d0372879dd8" memberName="mpeEnabled"
+                virtualName="LightedToggleButton" explicitFocusOrder="0" pos="448 288 56 24"
                 buttonText="" connectedEdges="0" needsCallback="1" radioGroupId="0"
                 state="0"/>
 </JUCER_COMPONENT>

--- a/Source/ParamDialog.h
+++ b/Source/ParamDialog.h
@@ -109,6 +109,8 @@ private:
     std::unique_ptr<TextButton> showTunButton;
     std::unique_ptr<TextButton> resetTuningButton;
     std::unique_ptr<LightedToggleButton> transposeScale;
+    std::unique_ptr<Slider> mpePBRange;
+    std::unique_ptr<LightedToggleButton> mpeEnabled;
 
 
     //==============================================================================

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -321,6 +321,8 @@ void DexedAudioProcessor::getStateInformation(MemoryBlock& destData) {
     //TRACE("saving opswitch %s", controllers.opSwitch);
     dexedState.setAttribute("opSwitch", controllers.opSwitch);
     dexedState.setAttribute("transpose12AsScale", controllers.transpose12AsScale ? 1 : 0 );
+    dexedState.setAttribute("mpeEnabled", controllers.mpeEnabled ? 1 : 0 );
+    dexedState.setAttribute("mpePitchBendRange", controllers.mpePitchBendRange );
     
     char mod_cfg[15];
     controllers.wheel.setConfig(mod_cfg);
@@ -398,6 +400,9 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
     monoMode = root->getIntAttribute("monoMode", 0);
     controllers.masterTune = root->getIntAttribute("masterTune", 0);
     controllers.transpose12AsScale = ( root->getIntAttribute("transpose12AsScale", 1) != 0 );
+
+    controllers.mpePitchBendRange = ( root->getIntAttribute("mpePitchBendRange", 24) );
+    controllers.mpeEnabled = ( root->getIntAttribute("mpeEnabled", 0) != 0 );
     
     File possibleCartridge = File(root->getStringAttribute("activeFileCartridge"));
     if ( possibleCartridge.exists() )

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -37,11 +37,17 @@
 #include "EngineOpl.h"
 
 struct ProcessorVoice {
+    int channel;
     int midi_note;
     int velocity;
     bool keydown;
     bool sustained;
     bool live;
+
+    int mpePitchBend;
+    int mpePressure;
+    int mpeTimbre;
+    
     Dx7Note *dx7_note;
 };
 
@@ -91,8 +97,8 @@ class DexedAudioProcessor  : public AudioProcessor, public AsyncUpdater, public 
     bool sendSysexChange;
     
     void processMidiMessage(const MidiMessage *msg);
-    void keydown(uint8_t pitch, uint8_t velo);
-    void keyup(uint8_t pitch);
+    void keydown(uint8_t chan, uint8_t pitch, uint8_t velo);
+    void keyup(uint8_t, uint8_t pitch, uint8_t velo);
     
     /**
      * this is called from the Audio thread to tell

--- a/Source/msfa/controllers.h
+++ b/Source/msfa/controllers.h
@@ -92,6 +92,10 @@ public:
     int masterTune;
 
     bool transpose12AsScale = true;
+
+    // MPE configuration. FIXME - make this switchable
+    bool mpeEnabled = true;
+    int mpePitchBendRange = 24;
     
     FmMod wheel;
     FmMod foot;
@@ -118,7 +122,6 @@ public:
         if ( ! ((wheel.eg || foot.eg) || (breath.eg || at.eg)) )
             eg_mod = 127;
         
-        TRACE("controllers refresh>>> amp_mod %d pitch_mod %d", amp_mod, pitch_mod);
     }
     
     FmCore *core;

--- a/Source/msfa/dx7note.cc
+++ b/Source/msfa/dx7note.cc
@@ -180,6 +180,11 @@ void Dx7Note::init(const uint8_t patch[156], int midinote, int velocity) {
     pitchmoddepth_ = (patch[139] * 165) >> 6;
     pitchmodsens_ = pitchmodsenstab[patch[143] & 7];
     ampmoddepth_ = (patch[140] * 165) >> 6;
+
+    // MPE default valeus
+    mpePitchBend = 8192;
+    mpeTimbre = 0;
+    mpePressure = 0;
 }
 
 void Dx7Note::compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay, const Controllers *ctrls) {
@@ -205,6 +210,13 @@ void Dx7Note::compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay, const Co
             pb = (pb * (8191 / stp)) << 11;
         }
     }
+
+    if( ctrls->mpeEnabled )
+    {
+        int d = ((float)( (mpePitchBend-0x2000) << 11 )) * ctrls->mpePitchBendRange / 12.0; 
+        pb += d;
+    }
+    
     int32_t pitch_base = pb + ctrls->masterTune;
     pitch_mod += pitch_base;
     

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -64,6 +64,10 @@ public:
 
     std::shared_ptr<TuningState> tuning_state_;
 
+    int mpePitchBend = 8192;
+    int mpePressure = 0;
+    int mpeTimbre = 0;
+    
 private:
     Env env_[6];
     FmOpParams params_[6];

--- a/scripts/build-mac-so.sh
+++ b/scripts/build-mac-so.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+xcodebuild build -target "Dexed - Standalone Plugin" -configuration Release -project Builds/MacOSX/Dexed.xcodeproj


### PR DESCRIPTION
This commit provides initial support for MPE. That support consists of

1. MPE Enabled mode and MPE Pitch Bend Range both on PARAM screen
2. All MPE gestures captured per voice (so aftertouch, timbre, pb, and off vel)
3. MPE voice management by channel when MPE is enabled
4. Pitch Bend modification in MPE mode to handle bend gestures

It does not include any mapping of the aftertouch, timbre, or off velocity

Addressed #1